### PR TITLE
fix navbar highlight

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import theme from "./assets/theme.json";
 import "./App.css";
 import Home from "./routes/Home";
 import StyleGuide from "./routes/StyleGuide";
-import Menu from "./routes/Menu";
+import UserHome from "./routes/UserHome";
 import Reward from "./routes/Reward";
 import CouponSent from "./routes/CouponSent";
 import ChallengeDetails from "./routes/ChallengeDetails";
@@ -23,13 +23,13 @@ function App() {
             <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/style-guide" element={<StyleGuide />} />
-              <Route path="/menu" element={<Menu />} />
+              <Route path="/user-home" element={<UserHome />} />
               <Route path="/reward" element={<Reward />} />
-              <Route path="/coupon-sent" element={<CouponSent />} />
-              <Route path="/challenge-details" element={<ChallengeDetails />} />
-              <Route path="/coupons" element={<Coupons />} />
-              <Route path="/join-challenge" element={<JoinChallange />} />
-              <Route path="/join-challange-success" element={<JoinChallangeSuccess />} />
+              <Route path="/reward/coupon-sent" element={<CouponSent />} />
+              <Route path="/reward/challenge-details" element={<ChallengeDetails />} />
+              <Route path="/reward/coupons" element={<Coupons />} />
+              <Route path="/reward/join-challenge" element={<JoinChallange />} />
+              <Route path="/reward/join-challange-success" element={<JoinChallangeSuccess />} />
             </Routes>
           </div>
           <Navbar />

--- a/src/App.js
+++ b/src/App.js
@@ -30,8 +30,8 @@ function App() {
               <Route path="/reward/coupon-sent" element={<CouponSent />} />
               <Route path="/reward/challenge-details" element={<ChallengeDetails />} />
               <Route path="/reward/coupons" element={<Coupons />} />
-              <Route path="/reward/join-challenge" element={<JoinChallange />} />
-              <Route path="/reward/join-challange-success" element={<JoinChallangeSuccess />} />
+              <Route path="/user-home/join-challenge" element={<JoinChallange />} />
+              <Route path="/user-home/join-challange-success" element={<JoinChallangeSuccess />} />
             </Routes>
           </div>
           <Navbar />

--- a/src/components/ChallengeModal.jsx
+++ b/src/components/ChallengeModal.jsx
@@ -24,7 +24,7 @@ const ChallengeModal = () => {
 
     const handleJoin = () => {
       setIsModalOpen(false);
-      navigate('/join-challenge');
+      navigate('/reward/join-challenge');
     };
 
     const handleSkip = () => {

--- a/src/components/ChallengeModal.jsx
+++ b/src/components/ChallengeModal.jsx
@@ -24,7 +24,7 @@ const ChallengeModal = () => {
 
     const handleJoin = () => {
       setIsModalOpen(false);
-      navigate('/reward/join-challenge');
+      navigate('/user-home/join-challenge');
     };
 
     const handleSkip = () => {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,26 +5,27 @@ import { FaRecycle } from "react-icons/fa";
 import { MdOutlineRestaurantMenu } from "react-icons/md";
 import { RiCoupon3Fill } from "react-icons/ri";
 
+
 const Navbar = () => {
   const location = useLocation();
 
+  if (location.pathname.startsWith('/user-home')) {
+    return null;
+  }
+
   const shouldHighlight = (route) => {
-    console.log("Current Path:", location.pathname, "Route:", route); 
-    if (route === '/community') {
-      return ['/community'].includes(location.pathname);
-    }
-    if (route === '/recycle') {
-      return ['/recycle'].includes(location.pathname);
-    }
-    if (route === '/menu') {
-      return ['/menu'].includes(location.pathname);
-    }
-    if (route === '/reward') {
-      return ['/reward', '/coupons', '/challenge-details', '/coupon-sent'].includes(location.pathname);
-    }
     return location.pathname.startsWith(route);
   };
 
+  const menuItemClassName = (isActive, route) => {
+    const baseClasses = "flex flex-col items-center justify-center py-2 px-1 w-full text-xs text-gray-700 no-underline";
+    const hoverClasses = "hover:text-primary hover:bg-gray-100";
+    const activeClasses = "text-primary bg-gray-100";
+    const responsiveClasses = "sm:px-4 sm:text-sm";
+  
+    return `${baseClasses} ${hoverClasses} ${isActive || shouldHighlight(route) ? activeClasses : ''} ${responsiveClasses}`;
+  };
+  
 
   return (
     <nav className="fixed inset-x-0 bottom-0 bg-white shadow z-10 py-2">
@@ -33,11 +34,7 @@ const Navbar = () => {
           <li className="flex-1">
           <NavLink 
               to="/community"
-              className={({ isActive }) => 
-                isActive || shouldHighlight('/community') 
-                  ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
-                  : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
-              }
+              className={({ isActive }) => menuItemClassName(isActive, '/community')}
             >
               <RiCommunityFill className="h-6 w-6" />
               <span>Community</span>
@@ -46,11 +43,7 @@ const Navbar = () => {
           <li className="flex-1">
               <NavLink 
                 to="/recycle"
-                className={({ isActive }) => 
-                  isActive || shouldHighlight('/recycle') 
-                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
-                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
-                }
+                className={({ isActive }) => menuItemClassName(isActive, '/recycle')}
               >
               <FaRecycle className="h-6 w-6" />
               <span>Recycle</span>
@@ -59,11 +52,7 @@ const Navbar = () => {
           <li className="flex-1">
               <NavLink 
                 to="/menu"
-                className={({ isActive }) => 
-                  isActive || shouldHighlight('/menu') 
-                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
-                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
-                }
+                className={({ isActive }) => menuItemClassName(isActive, '/menu')}
               >
               <MdOutlineRestaurantMenu className="h-6 w-6" />
               <span>Menu</span>
@@ -72,11 +61,7 @@ const Navbar = () => {
           <li className="flex-1">
               <NavLink 
                 to="/reward"
-                className={({ isActive }) => 
-                  isActive || shouldHighlight('/reward') 
-                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
-                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
-                }
+                className={({ isActive }) => menuItemClassName(isActive, '/reward')}
               >
               <RiCoupon3Fill className="h-6 w-6" />
               <span>Reward</span>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -37,7 +37,7 @@ const Navbar = () => {
               className={({ isActive }) => menuItemClassName(isActive, '/community')}
             >
               <RiCommunityFill className="h-6 w-6" />
-              <span>Community</span>
+              <span className='font-paragraph'>Community</span>
             </NavLink>
           </li>
           <li className="flex-1">
@@ -46,7 +46,7 @@ const Navbar = () => {
                 className={({ isActive }) => menuItemClassName(isActive, '/recycle')}
               >
               <FaRecycle className="h-6 w-6" />
-              <span>Recycle</span>
+              <span className='font-paragraph'>Recycle</span>
             </NavLink>
           </li>
           <li className="flex-1">
@@ -55,7 +55,7 @@ const Navbar = () => {
                 className={({ isActive }) => menuItemClassName(isActive, '/menu')}
               >
               <MdOutlineRestaurantMenu className="h-6 w-6" />
-              <span>Menu</span>
+              <span className='font-paragraph'>Menu</span>
             </NavLink>
           </li>
           <li className="flex-1">
@@ -64,7 +64,7 @@ const Navbar = () => {
                 className={({ isActive }) => menuItemClassName(isActive, '/reward')}
               >
               <RiCoupon3Fill className="h-6 w-6" />
-              <span>Reward</span>
+              <span className='font-paragraph'>Reward</span>
             </NavLink>
           </li>
         </ul>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,35 +1,83 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { RiCommunityFill } from "react-icons/ri";
 import { FaRecycle } from "react-icons/fa";
 import { MdOutlineRestaurantMenu } from "react-icons/md";
 import { RiCoupon3Fill } from "react-icons/ri";
 
 const Navbar = () => {
+  const location = useLocation();
+
+  const shouldHighlight = (route) => {
+    console.log("Current Path:", location.pathname, "Route:", route); 
+    if (route === '/community') {
+      return ['/community'].includes(location.pathname);
+    }
+    if (route === '/recycle') {
+      return ['/recycle'].includes(location.pathname);
+    }
+    if (route === '/menu') {
+      return ['/menu'].includes(location.pathname);
+    }
+    if (route === '/reward') {
+      return ['/reward', '/coupons', '/challenge-details', '/coupon-sent'].includes(location.pathname);
+    }
+    return location.pathname.startsWith(route);
+  };
+
+
   return (
     <nav className="fixed inset-x-0 bottom-0 bg-white shadow z-10 py-2">
       <div className="max-w-screen-xl mx-auto">
         <ul className="flex justify-between items-center list-none p-0 m-0">
           <li className="flex-1">
-            <NavLink to="/community" className="flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline">
+          <NavLink 
+              to="/community"
+              className={({ isActive }) => 
+                isActive || shouldHighlight('/community') 
+                  ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
+                  : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
+              }
+            >
               <RiCommunityFill className="h-6 w-6" />
               <span>Community</span>
             </NavLink>
           </li>
           <li className="flex-1">
-            <NavLink to="/style-guide" className="flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline">
+              <NavLink 
+                to="/recycle"
+                className={({ isActive }) => 
+                  isActive || shouldHighlight('/recycle') 
+                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
+                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
+                }
+              >
               <FaRecycle className="h-6 w-6" />
               <span>Recycle</span>
             </NavLink>
           </li>
           <li className="flex-1">
-            <NavLink to="/menu" className="flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline">
+              <NavLink 
+                to="/menu"
+                className={({ isActive }) => 
+                  isActive || shouldHighlight('/menu') 
+                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
+                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
+                }
+              >
               <MdOutlineRestaurantMenu className="h-6 w-6" />
               <span>Menu</span>
             </NavLink>
           </li>
           <li className="flex-1">
-            <NavLink to="/reward" className="flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline">
+              <NavLink 
+                to="/reward"
+                className={({ isActive }) => 
+                  isActive || shouldHighlight('/reward') 
+                    ? "text-primary bg-gray-200 flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm no-underline"
+                    : "flex flex-col items-center justify-center py-2 px-1 sm:px-4 w-full text-xs sm:text-sm text-gray-700 hover:text-gray-900 hover:bg-gray-100 no-underline"
+                }
+              >
               <RiCoupon3Fill className="h-6 w-6" />
               <span>Reward</span>
             </NavLink>

--- a/src/routes/Coupons.jsx
+++ b/src/routes/Coupons.jsx
@@ -15,9 +15,9 @@ const Coupons = () => {
 
     const { TextArea } = Input;
     const [coupons, setCoupons] = useState([
-        { id: 1, description: '¥3 - within 15 days' },
-        { id: 2, description: '¥5 - buy $50 save $5' },
-        { id: 3, description: '¥20 - buy $150 save $20' }
+        { id: 1, description: '¥3 - above $30' },
+        { id: 2, description: '¥5 - above $50' },
+        { id: 3, description: '¥20 - above $150' }
     ]);
     const [showAddCoupon, setShowAddCoupon] = useState(false);
     const [newCouponTitle, setNewCouponTitle] = useState('');

--- a/src/routes/JoinChallange.jsx
+++ b/src/routes/JoinChallange.jsx
@@ -20,7 +20,7 @@ const JoinChallange = () => {
     };
 
     const handleJoin = () => {
-        navigate('/reward/Join-challange-success');
+        navigate('/user-home/Join-challange-success');
     }
 
     const handleSkip = () => {

--- a/src/routes/JoinChallange.jsx
+++ b/src/routes/JoinChallange.jsx
@@ -20,11 +20,11 @@ const JoinChallange = () => {
     };
 
     const handleJoin = () => {
-        navigate('/Join-challange-success');
+        navigate('/reward/Join-challange-success');
     }
 
     const handleSkip = () => {
-        navigate('/menu', { state: { skipModal: true } });
+        navigate('/user-home', { state: { skipModal: true } });
     }
 
     return (    

--- a/src/routes/JoinChallangeSuccess.jsx
+++ b/src/routes/JoinChallangeSuccess.jsx
@@ -9,8 +9,8 @@ import Paragraph from "../components/Paragraph";
 const JoinChallangeSuccess = () => {
     const navigate = useNavigate();
 
-    const handleReturnToMenu = () => {
-        navigate('/menu', { state: { skipModal: true, fromJoinSuccess: true } });
+    const handleReturnToUserHome = () => {
+        navigate('/user-home', { state: { skipModal: true, fromJoinSuccess: true } });
     };
 
 
@@ -31,7 +31,7 @@ const JoinChallangeSuccess = () => {
             </Flex>
         </Flex> 
         <Flex vertical center className="px-20 py-20">
-            <CustomButton type="primary" onClick={handleReturnToMenu}>RETURN TO MENU</CustomButton>
+            <CustomButton type="primary" onClick={handleReturnToUserHome}>RETURN TO MENU</CustomButton>
         </Flex>
     </div>);
 };

--- a/src/routes/Reward.jsx
+++ b/src/routes/Reward.jsx
@@ -26,15 +26,15 @@ const Reward = () => {
     const navigate = useNavigate();
 
     const handleSendCoupon = () => {
-        navigate('/coupon-sent');
+        navigate('/reward/coupon-sent');
     };
 
     const handleViewDetails = () => {
-        navigate('/challenge-details');
+        navigate('/reward/challenge-details');
     };
 
     const handleManageCoupons = () => {
-        navigate('/coupons');
+        navigate('/reward/coupons');
     };
 
 

--- a/src/routes/UserHome.jsx
+++ b/src/routes/UserHome.jsx
@@ -9,11 +9,11 @@ const UserHome = () => {
     const fromJoinSuccess = location.state?.fromJoinSuccess;
 
     const handleJoin = () => {
-        navigate('/reward/join-challenge');
+        navigate('/user-home/join-challenge');
     }
 
     const handleJoinSuccess = () => {
-        navigate('/reward/join-challange-success');
+        navigate('/user-home/join-challange-success');
     }
 
     return (    

--- a/src/routes/UserHome.jsx
+++ b/src/routes/UserHome.jsx
@@ -3,17 +3,17 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import ChallengeModal from "../components/ChallengeModal";
 import Link from "../components/Link";
 
-const Menu = () => {
+const UserHome = () => {
     const navigate = useNavigate();
     const location = useLocation();
     const fromJoinSuccess = location.state?.fromJoinSuccess;
 
     const handleJoin = () => {
-        navigate('/join-challenge');
+        navigate('/reward/join-challenge');
     }
 
     const handleJoinSuccess = () => {
-        navigate('/join-challange-success');
+        navigate('/reward/join-challange-success');
     }
 
     return (    
@@ -33,4 +33,4 @@ const Menu = () => {
     );
 };
 
-export default Menu;
+export default UserHome;


### PR DESCRIPTION
fix navbar highlight.
routes always have corresponding navbar hightlight.

preview: 
![Screen Shot 2023-12-04 at 00 21 11](https://github.com/congruiyS2023/platemate-web/assets/123203441/9b0983fa-0541-4d71-a25d-97252c390bbf)



navbar can stay highlight for routes starting in `/{featureName} `
example usage:
![Screen Shot 2023-12-04 at 00 10 07](https://github.com/congruiyS2023/platemate-web/assets/123203441/09235c91-2bae-4e83-9a14-b7d54ac3e1a0)

 
now navbar is hidden for route `/user-home`
![Screen Shot 2023-12-04 at 00 04 06](https://github.com/congruiyS2023/platemate-web/assets/123203441/ba2cdffc-4132-49ec-8e0e-7e64d87b4285)


