### PR TITLE
Fix quantity decrement in Community component

### DIFF
--- a/src/routes/Community.jsx
+++ b/src/routes/Community.jsx
@@ -85,7 +85,7 @@ const Community = () => {
             if (post.id === id) {
                 return {
                     ...post,
-                    quantity: post.quantity - 1
+                    quantity: Math.max(post.quantity - 1, 0)
                 }
             }
             return post;


### PR DESCRIPTION
Fixed a bug, this bug used to enable users to set the quantity of the food in redistribution post to negative values when continuously clicking on the minus button on the card.