### PR TITLE
Add text-center class to StyleGuide heading

### DIFF
--- a/src/routes/StyleGuide.jsx
+++ b/src/routes/StyleGuide.jsx
@@ -52,7 +52,7 @@ const StyleGuide = () => {
 
   return (
     <>
-      <div className="pt-4">
+      <div className="pt-4 text-center">
         <Heading level={1}>PlateMate Style Guide</Heading>
       </div>
       <Divider />


### PR DESCRIPTION
Fixed a bug, this bug once made the title of style guide page to align to left.